### PR TITLE
Modified content components to use <slot /> elements where appropriate

### DIFF
--- a/components/content/ComingSoon.vue
+++ b/components/content/ComingSoon.vue
@@ -10,23 +10,28 @@
             >
                 <v-card-title >
                     <v-icon>mdi-folder-wrench-outline</v-icon>
-                    {{ title }}
+                    <slot name="title">
+                        Under construction ...
+                    </slot>
                 </v-card-title>
-                <div v-if="subtitle">
-                    <v-divider></v-divider>
-                    <v-card-subtitle v-text="subtitle"></v-card-subtitle>
+                <div>
+                    <v-divider class="white text-white"></v-divider>
+                    <v-card-subtitle>
+                        <slot name="subtitle" />
+                    </v-card-subtitle>
                 </div>
             </v-img>
-            <v-card-text v-text="text" class="pa-4"></v-card-text>
+            <v-card-text class="pa-4">
+                <slot name="text">
+                    This section of this site is currently being worked on to ensure it's fabulous.  Check back later to be amazed!
+                </slot>
+            </v-card-text>
         </v-card>
     </v-row>
 </template>
 
 <script setup lang="js">
 const props = defineProps({
-    title: {type: String, required: false, default: "Under construction ..."},
-    subtitle: {type: String, required: false},
-    text: {type: String, required: false, default: "This section of this site is currently being worked on to ensure it's fabulous.  Check back later to be amazed!"},
     img_src: {type: String, required: false, default: "/img/components/construction.jpeg"}
 })
 </script>

--- a/components/content/PageHeader.vue
+++ b/components/content/PageHeader.vue
@@ -1,12 +1,9 @@
 <template>
-    <p class="text-h2">{{ props.title }}</p>
+    <p class="text-h2">
+        <slot name="title" />
+    </p>
     <v-divider class="my-2" />
-    <p class="text-h6" > {{ props.subtitle }}</p>
+    <p> 
+        <slot name="subtitle" />
+    </p>
 </template>
-
-<script setup>
-const props = defineProps({
-    title: String,
-    subtitle: String
-})
-</script>

--- a/content/photos/index.md
+++ b/content/photos/index.md
@@ -3,8 +3,15 @@ title: Photos
 description: Header content of photos page
 ---
 
-:::PageHeader{title="Photos of Supermanzer" subtitle="I am a pretty basic amateur photographer but I do take joy in taking photographs.  I am using this section of my site to explore how best to share those photographs and what kinds of technical challenges I will have to solve to produce the experience I want."}
+:::PageHeader
+#title
+Photos of Supermanzer 
+
+#subtitle
+I am a pretty basic amateur photographer but I do take joy in taking photographs.  I am using this section of my site to explore how best to share those photographs and what kinds of technical challenges I will have to solve to produce the experience I want.
 :::
 
-:::ComingSoon{subtitle="Actual photos coming soon"}
+:::ComingSoon
+#subtitle
+Actual photos coming soon
 :::

--- a/content/projects/index.md
+++ b/content/projects/index.md
@@ -3,5 +3,10 @@ title: Projects
 description: Header content for the Projects homepage
 ---
 
-:::PageHeader{title="My Projects" subtitle="I like building things"}
+:::PageHeader
+
+#title
+My Projects 
+#subtitle
+I like building things
 :::

--- a/content/stripe/index.md
+++ b/content/stripe/index.md
@@ -3,8 +3,16 @@ title: Stripe
 description: Header content for the main Stripe page
 ---
 
-:::PageHeader{title="Stripe Integrations" subtitle="This section of my site is dedicated to discussing and providing examples of Stripe front-end integrations.  My goal is to provide working examples that share both a usable UI as well as the code on both the client and server."}
+:::PageHeader
+#title
+Stripe Integrations 
+
+#subtitle
+This section of my site is dedicated to discussing and providing examples of Stripe front-end integrations.  My goal is to provide working examples that share both a usable UI as well as the code on both the client and server.
 :::
 
-:::ComingSoon{subtitle="Nifty integrations coming soon"}
+:::ComingSoon
+
+#subtitle
+Nifty integrations coming soon
 :::


### PR DESCRIPTION
## Summary
This PR modifies the `PageHeader.vue` and `ComingSoon.Vue` components in the `content` namespace.  It replaces the use of props for text sections with the use of named slots.

## Motivation
The syntax for passing props in NuxtContent markdown files works well for small values but, when passing larger amounts of text, it can impact readability.  The reason behind this PR is to align on using named slots instead of props to maintain greater readability of content markdown files that utilize custom components and pass larger amounts of text to them.  Future development of custom content components should follow this approach.